### PR TITLE
Add license refrence to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ of servers to the toolbar.
 
 **Copyright (c) 2016-2018**  
 ![NOKIA](https://raw.githubusercontent.com/nokia/atom-netconf/master/logo-tiny.png)
+
+
+## License
+
+This project is licensed under the MIT license - see the [LICENSE](https://github.com/nokia/atom-netconf/blob/master/LICENSE).


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.